### PR TITLE
Run build and deploy edge-miner

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,7 @@ jobs:
             ${{ runner.os }}-turbo-${{ hashFiles('**/yarn.lock') }}-
             ${{ runner.os }}-turbo-
 
-      - run: yarn turbo run build --filter=apps/edge-miner
+      - run: yarn turbo run build --filter=@parlay/edge-miner
 
       - uses: digitalocean/action-doctl@v2
         with:


### PR DESCRIPTION
Fix Turborepo filter in deploy workflow to correctly build the `edge-miner` package.

The previous filter `apps/edge-miner` was not recognized by Turborepo as a valid package name or path, leading to "No tasks were executed". This resulted in an empty `dist/` directory and a "Nothing deployed" error in the subsequent `doctl serverless deploy` step. The updated filter `@parlay/edge-miner` targets the correct package name, ensuring the build artifact is created.