### PR TITLE
Fix TypeScript module resolution errors

### DIFF
--- a/apps/edge-miner/tsconfig.json
+++ b/apps/edge-miner/tsconfig.json
@@ -2,7 +2,6 @@
     "extends": "../../tsconfig.base.json",
     "compilerOptions": {
         "outDir": "dist",
-        "rootDir": "src",
         "types": [
             "node",
             "jest"


### PR DESCRIPTION
Remove `rootDir` from `apps/edge-miner/tsconfig.json` to resolve module import errors.

The `rootDir: "src"` setting prevented TypeScript from resolving path aliases to modules located outside the `src` directory, leading to "Cannot find module" errors during the build. Removing it allows TypeScript to correctly resolve these imports.